### PR TITLE
BaseDistribution: Add naive .plot()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ pprint(sq.get_percentiles(samples, digits=0))
 # Histogram
 plt.hist(samples, bins=200)
 plt.show()
+
+# Shorter histogram
+total_tuners_in_2022.plot()
 ```
 
 And the version from the Squiggle doc that incorporates time:

--- a/squigglepy/distributions.py
+++ b/squigglepy/distributions.py
@@ -1,6 +1,7 @@
 import operator
 import math
 import numpy as np
+from matplotlib import pyplot as plt
 from scipy import stats
 
 from .utils import _process_weights_values, _is_numpy, is_dist, _round
@@ -40,6 +41,14 @@ class BaseDistribution:
     def __repr__(self):
         return str(self)
 
+    def plot(self, num_samples=None, bins=None):
+        num_samples = 1000 if num_samples is None else num_samples
+        bins = 200 if bins is None else bins
+
+        samples = self @ num_samples
+
+        plt.hist(samples, bins=bins)
+        plt.show()
 
 class OperableDistribution(BaseDistribution):
     def __init__(self):


### PR DESCRIPTION
Nothing fancy, just replace

```
samples = total_tuners_in_2022 @ 1000
plt.hist(samples, bins=200)
plt.show()
```

with

```
total_tuners_in_2022.plot()
```

I think more can be done here, like using Seaborn, but I tried keeping this PR simple and uncontroversial.

The old functionality is still supported, so this shouldn't break anything.

Regarding this:
`num_samples=None, bins=None`, I decided to leave flexibility for the implementation to decide on the num_samples if the user defines the bins, and vice versa, but this isn't a strong opinion.

Fixes #4