### PR TITLE
Fix pareto_sample to sample from Pareto dist instead of Lomax

### DIFF
--- a/squigglepy/samplers.py
+++ b/squigglepy/samplers.py
@@ -473,7 +473,9 @@ def pareto_sample(shape, samples=1):
     >>> pareto_sample(1)
     10.069666324736094
     """
-    return _simplify(_get_rng().pareto(shape, samples))
+    # Add 1 because Numpy's "pareto" sampler actually samples from a Lomax
+    # distribution
+    return _simplify(_get_rng().pareto(shape, samples) + 1)
 
 
 def uniform_sample(low, high, samples=1):

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -365,7 +365,7 @@ def test_sample_gamma_passes_lclip_rclip():
 
 @patch.object(samplers, "_get_rng", Mock(return_value=FakeRNG()))
 def test_sample_pareto_default():
-    assert sample(pareto(10)) == 10
+    assert sample(pareto(10)) == 11
 
 
 @patch.object(samplers, "_get_rng", Mock(return_value=FakeRNG()))


### PR DESCRIPTION
`numpy.random.pareto` actually samples from a Lomax distribution for some ungodly reason (see [docs](https://numpy.org/doc/stable/reference/random/generated/numpy.random.pareto.html)). I could see a couple ways to handle this in Squigglepy:

1. When sampling, convert the Lomax to a Pareto
2. Keep using Lomax, and explain in the docstrings for ParetoDistribution/sample_pareto that it's actually Lomax (maybe also change the names)

I went with the first fix because a Pareto distribution works better for an upcoming PR I am writing for Squigglepy (which is much more fun than this one). IMO a Lomax distribution makes more sense for most real-world purposes but it's harder to work with mathematically and it's not used as often.