### PR TITLE
Analytic methods

### DIFF
--- a/squigglepy/distributions.py
+++ b/squigglepy/distributions.py
@@ -1829,6 +1829,15 @@ class FlatTree:
                     fn_str="*",
                 )
             )
+        if dist.fn == operator.truediv and isinstance(dist.right, LognormalDistribution):
+            return cls.build(
+                ComplexDistribution(
+                    dist.left,
+                    LognormalDistribution(norm_mean=-dist.right.norm_mean, norm_sd=dist.right.norm_sd),
+                    fn=operator.mul,
+                    fn_str="*",
+                )
+            )
 
         left_tree = cls.build(dist.left)
         right_tree = cls.build(dist.right)
@@ -2024,24 +2033,12 @@ class FlatTree:
                 ),
                 commutative=False,
             )
-            # self._join_dists(
-            #     LognormalDistribution,
-            #     Real,
-            #     lambda x, y: self._lognormal_times_const(x.norm_mean, x.norm_sd, 1 / y),
-            #     commutative=False,
-            # )
             self._join_dists(
                 Real,
                 LognormalDistribution,
                 lambda x, y: self._lognormal_times_const(-y.norm_mean, y.norm_sd, x),
                 commutative=False,
             )
-            # self._join_dists(
-            #     NormalDistribution,
-            #     Real,
-            #     lambda x, y: NormalDistribution(mean=x.mean / y, sd=x.sd / y),
-            #     commutative=False,
-            # )
 
         elif self.fn == operator.pow:
             self._join_dists(

--- a/squigglepy/distributions.py
+++ b/squigglepy/distributions.py
@@ -1819,7 +1819,10 @@ class FlatTree:
         acc_index = None
         acc_is_left = True
         for i, x in enumerate(self.dists):
-            if acc is None and isinstance(x, left_type):
+            if isinstance(x, BaseDistribution) and (x.lclip is not None or x.rclip is not None):
+                # We can't simplify a clipped distribution
+                simplified_dists.append(x)
+            elif acc is None and isinstance(x, left_type):
                 acc = x
                 acc_index = i
             elif (

--- a/squigglepy/distributions.py
+++ b/squigglepy/distributions.py
@@ -173,9 +173,6 @@ class OperableDistribution(BaseDistribution):
     def __hash__(self):
         return hash(repr(self))
 
-    def _build_flat_tree(self):
-        return FlatTree.leaf(self)
-
     def simplify(self):
         return self
 
@@ -249,15 +246,8 @@ class ComplexDistribution(CompositeDistribution):
             raise ValueError
         return out
 
-    def _build_flat_tree(self):
-        left_tree = self.left._build_flat_tree()
-        right_tree = None
-        if self.right is not None:
-            right_tree = self.right._build_flat_tree()
-        return FlatTree.branch(self.fn, left_tree, right_tree)
-
     def simplify(self):
-        return self._build_flat_tree().simplify()
+        return FlatTree.build(self).simplify()
 
 
 def _get_fname(f, name):
@@ -1735,56 +1725,81 @@ class FlatTree:
             raise ValueError("Missing arguments to FlatTree constructor")
 
     @classmethod
-    def leaf(cls, dist):
-        return FlatTree(dist=dist)
+    def build(cls, dist):
+        if isinstance(dist, int) or isinstance(dist, float):
+            return FlatTree(dist=float(dist))
+        if not isinstance(dist, BaseDistribution):
+            import ipdb; ipdb.set_trace()
+            raise ValueError(f"dist must be a BaseDistribution or numeric type, not {type(dist)}")
+        if not isinstance(dist, ComplexDistribution):
+            return FlatTree(dist=dist)
 
-    @classmethod
-    def branch(cls, fn, left_tree, right_tree):
         # make a list of possibly-joinable distributions, plus a list of
         # children as trees who could not be simplified at this level
         dists = []
         children = []
-        is_unary = right_tree is None
-        if is_unary and right_tree is not None:
-            raise ValueError(f"Multiple arguments provided for unary operator {fn}")
-        if fn == operator.neg and left_tree.is_leaf:
-            dist = left_tree.dist
-            if isinstance(dist, NormalDistribution):
-                return cls.leaf(NormalDistribution(mean=-dist.mean, sd=dist.sd))
-        if fn == operator.sub:
-            return cls.branch(
-                operator.add,
-                left_tree,
-                FlatTree.branch(operator.neg, right_tree, None)
+        is_unary = dist.right is None
+        if is_unary and dist.right is not None:
+            raise ValueError(f"Multiple arguments provided for unary operator {dist.fn}")
+        if dist.fn == operator.neg:
+            if isinstance(dist.left, NormalDistribution):
+                return cls.build(NormalDistribution(mean=-dist.left.mean, sd=dist.left.sd))
+        if dist.fn == operator.sub:
+            return cls.build(
+                ComplexDistribution(
+                    dist.left,
+                    ComplexDistribution(
+                        dist.right,
+                        right=None,
+                        fn=operator.neg,
+                        fn_str="-"
+                    ),
+                    fn=operator.add,
+                    fn_str="+"
+                )
             )
+
+        left_tree = cls.build(dist.left)
+        right_tree = cls.build(dist.right)
 
         if left_tree.is_leaf:
             dists.append(left_tree.dist)
-        elif left_tree.fn == fn and fn in cls.COMMUTABLE_OPERATIONS:
+        elif left_tree.fn == dist.fn and dist.fn in cls.COMMUTABLE_OPERATIONS:
             dists.extend(left_tree.dists)
         else:
             children.append(left_tree)
         if right_tree is not None:
             if right_tree.is_leaf:
                 dists.append(right_tree.dist)
-            elif right_tree.fn == fn and fn in cls.COMMUTABLE_OPERATIONS:
+            elif right_tree.fn == dist.fn and dist.fn in cls.COMMUTABLE_OPERATIONS:
                 dists.extend(right_tree.dists)
             else:
                 children.append(right_tree)
 
         dists.sort(key=lambda d: type(d).__name__)
 
-        return cls(fn=fn, dists=dists, children=children, is_unary=is_unary)
+        return cls(fn=dist.fn, dists=dists, children=children, is_unary=is_unary)
 
-    def _join_dists(self, name, join_fn):
-        dist_indexes = [i for i in range(len(self.dists)) if type(self.dists[i]).__name__ == name]
-        if len(dist_indexes) == 0:
-            return None
-        first_index = dist_indexes[0]
-        for i in dist_indexes[1:]:
-            self.dists[first_index] = join_fn(self.dists[first_index], self.dists[i])
-            self.dists[i] = None
-        self.dists = [d for d in self.dists if d is not None]
+    def _join_dists(self, left_type, right_type, join_fn, commutative=True):
+        dists = []
+        acc = None
+        acc_is_left = True
+        for x in self.dists:
+            if acc is None and isinstance(x, left_type):
+                acc = x
+            elif acc is None and commutative and isinstance(x, right_type):
+                acc = x
+                acc_is_left = False
+            elif acc is not None and isinstance(x, right_type) and acc_is_left:
+                acc = join_fn(acc, x)
+            elif acc is not None and commutative and isinstance(x, left_type) and not acc_is_left:
+                acc = join_fn(x, acc)
+            else:
+                dists.append(x)
+
+        if acc is not None:
+            dists.insert(0, acc)
+        self.dists = dists
 
     def simplify(self):
         if self.is_leaf:
@@ -1792,12 +1807,11 @@ class FlatTree:
 
         simplified_children = [child.simplify() for child in self.children]
         if self.fn == operator.add:
-            self._join_dists("NormalDistribution", lambda x, y: NormalDistribution(mean=x.mean + y.mean, sd=np.sqrt(x.sd**2 + y.sd**2)))
-            self._join_dists("float", lambda x, y: x + y)
-            self._join_dists("int", lambda x, y: x + y)
+            self._join_dists(NormalDistribution, NormalDistribution, lambda x, y: NormalDistribution(mean=x.mean + y.mean, sd=np.sqrt(x.sd**2 + y.sd**2)))
+            self._join_dists(NormalDistribution, float, lambda x, y: NormalDistribution(mean=x.mean + y, sd=x.sd))
         elif self.fn == operator.mul:
-            self._join_dists("LognormalDistribution", lambda x, y: LognormalDistribution(norm_mean=x.norm_mean + y.norm_mean, norm_sd=np.sqrt(x.norm_sd**2 + y.norm_sd**2)))
-            self._join_dists("float", lambda x, y: x * y)
-            self._join_dists("int", lambda x, y: x * y)
+            self._join_dists(LognormalDistribution, LognormalDistribution, lambda x, y: LognormalDistribution(norm_mean=x.norm_mean + y.norm_mean, norm_sd=np.sqrt(x.norm_sd**2 + y.norm_sd**2)))
+            self._join_dists(LognormalDistribution, float, lambda x, y: LognormalDistribution(norm_mean=x.norm_mean * y, norm_sd=x.norm_sd))
+            self._join_dists(NormalDistribution, float, lambda x, y: NormalDistribution(mean=x.mean * y, sd=x.sd * y))
 
         return reduce(lambda acc, x: ComplexDistribution(acc, x), simplified_children + self.dists)

--- a/squigglepy/samplers.py
+++ b/squigglepy/samplers.py
@@ -39,6 +39,7 @@ from .distributions import (
     LognormalDistribution,
     MixtureDistribution,
     NormalDistribution,
+    OperableDistribution,
     ParetoDistribution,
     PoissonDistribution,
     TDistribution,
@@ -876,6 +877,10 @@ def sample(
 
     if verbose is None:
         verbose = n >= 1000000
+
+    # Simplify distribution analytically before sampling
+    if isinstance(dist, OperableDistribution):
+        dist = dist.simplify()
 
     # Handle loading from cache
     samples = None

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -848,11 +848,12 @@ def test_sample_callable_resolves_fully():
     assert sample(sample_fn) == 5
 
 
+@patch.object(samplers, "gamma_sample", Mock(return_value=1))
 @patch.object(samplers, "normal_sample", Mock(return_value=1))
 @patch.object(samplers, "lognormal_sample", Mock(return_value=4))
 def test_sample_callable_resolves_fully2():
     def really_inner_sample_fn():
-        return 1
+        return gamma(1, 4)
 
     def inner_sample_fn():
         return norm(1, 4) + lognorm(1, 10) + really_inner_sample_fn()
@@ -870,15 +871,16 @@ def test_sample_invalid_input():
 
 
 @patch.object(samplers, "normal_sample", Mock(return_value=100))
+@patch.object(samplers, "lognormal_sample", Mock(return_value=100))
 def test_sample_math():
-    assert ~(norm(0, 1) + norm(1, 2)) == 200
+    assert ~(norm(0, 1) + lognorm(1, 2)) == 200
 
 
 @patch.object(samplers, "normal_sample", Mock(return_value=10))
 @patch.object(samplers, "lognormal_sample", Mock(return_value=100))
 def test_sample_complex_math():
-    obj = (2 ** norm(0, 1)) - (8 * 6) + 2 + (lognorm(10, 100) / 11) + 8
-    expected = (2**10) - (8 * 6) + 2 + (100 / 11) + 8
+    obj = (2 ** norm(0, 1)) - (8 * 6) + 2 + (lognorm(10, 100) + 11) / 8
+    expected = (2**10) - (8 * 6) + 2 + (100 + 11) / 8
     assert ~obj == expected
 
 

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -33,11 +33,11 @@ def test_simplify_add_3_normals():
 def test_simplify_normal_plus_const():
     x = NormalDistribution(mean=0, sd=1)
     y = 2
-    sum2 = x + y
-    simplified = sum2.simplify()
+    z = NormalDistribution(mean=1, sd=1)
+    simplified = (x + y + z).simplify()
     assert isinstance(simplified, NormalDistribution)
-    assert simplified.mean == 2
-    assert simplified.sd == approx(1)
+    assert simplified.mean == 3
+    assert simplified.sd == approx(np.sqrt(2))
 
 def simplify_scale_normal():
     x = NormalDistribution(mean=2, sd=4)
@@ -48,7 +48,7 @@ def simplify_scale_normal():
     assert simplified.mean == approx(3)
     assert simplified.sd == approx(6)
 
-def test_simplify_mul_3_normals():
+def test_simplify_mul_3_lognorms():
     x = LognormalDistribution(norm_mean=1, norm_sd=1)
     y = LognormalDistribution(norm_mean=2, norm_sd=2)
     z = LognormalDistribution(norm_mean=-2, norm_sd=3)
@@ -63,7 +63,7 @@ def test_simplify_mul_3_normals():
     assert simplified3_right.norm_mean == 1
     assert simplified3_right.norm_sd == approx(np.sqrt(1 + 4 + 9))
 
-def test_simplify_sub():
+def test_simplify_sub_normals():
     x = NormalDistribution(mean=1, sd=1)
     y = NormalDistribution(mean=2, sd=2)
     difference = x - y
@@ -71,3 +71,46 @@ def test_simplify_sub():
     assert isinstance(simplified, NormalDistribution)
     assert simplified.mean == -1
     assert simplified.sd == approx(np.sqrt(5))
+
+def test_simplify_normal_minus_const():
+    x = NormalDistribution(mean=0, sd=1)
+    y = 2
+    simplified = (x - y).simplify()
+    assert isinstance(simplified, NormalDistribution)
+    assert simplified.mean == -2
+    assert simplified.sd == approx(1)
+
+@given(
+    norm_mean=st.floats(min_value=-10, max_value=10),
+    norm_sd=st.floats(min_value=0.1, max_value=3),
+    y=st.floats(min_value=0.1, max_value=10),
+)
+def test_simplify_div_lognormal_by_constant(norm_mean, norm_sd, y):
+    x = LognormalDistribution(norm_mean=norm_mean, norm_sd=norm_sd)
+    simplified = (x / y).simplify()
+    assert isinstance(simplified, LognormalDistribution)
+    assert simplified.norm_mean == approx(norm_mean - np.log(y))
+    assert simplified.norm_sd == approx(norm_sd)
+
+@given(
+    x=st.floats(min_value=0.1, max_value=10),
+    norm_mean=st.floats(min_value=-10, max_value=10),
+    norm_sd=st.floats(min_value=0.1, max_value=3)
+)
+@example(x=1, norm_mean=0, norm_sd=1)
+def test_simplify_div_constant_by_lognormal(x, norm_mean, norm_sd):
+    y = LognormalDistribution(norm_mean=norm_mean, norm_sd=norm_sd)
+    simplified = (x / y).simplify()
+    assert isinstance(simplified, LognormalDistribution)
+    assert simplified.norm_mean == approx(np.log(x) - norm_mean)
+    assert simplified.norm_sd == approx(norm_sd)
+
+
+def test_simplify_lognormals():
+    x = LognormalDistribution(norm_mean=1, norm_sd=1)
+    y = LognormalDistribution(norm_mean=2, norm_sd=2)
+    quotient = x / y
+    simplified = quotient.simplify()
+    assert isinstance(simplified, LognormalDistribution)
+    assert simplified.norm_mean == -1
+    assert simplified.norm_sd == approx(np.sqrt(5))

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -146,13 +146,28 @@ def test_simplify_div_const_by_normal():
 def test_simplify_lognorm_pow():
     x = LognormalDistribution(norm_mean=3, norm_sd=2)
     y = 2
-    product = x ** y
+    product = x**y
     simplified = product.simplify()
     assert isinstance(simplified, LognormalDistribution)
     assert simplified.norm_mean == approx(6)
     assert simplified.norm_sd == approx(4)
 
     y = -1
-    product = x ** y
+    product = x**y
     simplified = product.simplify()
     assert isinstance(simplified, ComplexDistribution)
+
+
+def test_simplify_clipped_normal():
+    x = NormalDistribution(mean=1, sd=1)
+    y = NormalDistribution(mean=0, sd=1, lclip=1)
+    z = NormalDistribution(mean=3, sd=2)
+    simplified = (x + y + z).simplify()
+    assert isinstance(simplified, ComplexDistribution)
+    assert isinstance(simplified.left, NormalDistribution)
+    assert isinstance(simplified.right, NormalDistribution)
+    assert simplified.left.mean == 4
+    assert simplified.left.sd == approx(np.sqrt(5))
+    assert simplified.right.mean == 0
+    assert simplified.right.sd == 1
+    assert simplified.right.lclip == 1

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -6,6 +6,7 @@ from pytest import approx
 
 from ..squigglepy.distributions import *
 
+
 def test_simplify_add_normal():
     x = NormalDistribution(mean=1, sd=1)
     y = NormalDistribution(mean=2, sd=2)
@@ -14,6 +15,7 @@ def test_simplify_add_normal():
     assert isinstance(simplified2, NormalDistribution)
     assert simplified2.mean == 3
     assert simplified2.sd == approx(np.sqrt(5))
+
 
 def test_simplify_add_3_normals():
     x = NormalDistribution(mean=1, sd=1)
@@ -30,6 +32,7 @@ def test_simplify_add_3_normals():
     assert simplified3_right.mean == 0
     assert simplified3_right.sd == approx(np.sqrt(1 + 4 + 4))
 
+
 def test_simplify_normal_plus_const():
     x = NormalDistribution(mean=0, sd=1)
     y = 2
@@ -39,6 +42,7 @@ def test_simplify_normal_plus_const():
     assert simplified.mean == 3
     assert simplified.sd == approx(np.sqrt(2))
 
+
 def simplify_scale_normal():
     x = NormalDistribution(mean=2, sd=4)
     y = 1.5
@@ -47,6 +51,7 @@ def simplify_scale_normal():
     assert isinstance(simplified, NormalDistribution)
     assert simplified.mean == approx(3)
     assert simplified.sd == approx(6)
+
 
 def test_simplify_mul_3_lognorms():
     x = LognormalDistribution(norm_mean=1, norm_sd=1)
@@ -63,6 +68,7 @@ def test_simplify_mul_3_lognorms():
     assert simplified3_right.norm_mean == 1
     assert simplified3_right.norm_sd == approx(np.sqrt(1 + 4 + 9))
 
+
 def test_simplify_sub_normals():
     x = NormalDistribution(mean=1, sd=1)
     y = NormalDistribution(mean=2, sd=2)
@@ -72,6 +78,7 @@ def test_simplify_sub_normals():
     assert simplified.mean == -1
     assert simplified.sd == approx(np.sqrt(5))
 
+
 def test_simplify_normal_minus_const():
     x = NormalDistribution(mean=0, sd=1)
     y = 2
@@ -79,6 +86,7 @@ def test_simplify_normal_minus_const():
     assert isinstance(simplified, NormalDistribution)
     assert simplified.mean == -2
     assert simplified.sd == approx(1)
+
 
 @given(
     norm_mean=st.floats(min_value=-10, max_value=10),
@@ -92,10 +100,11 @@ def test_simplify_div_lognormal_by_constant(norm_mean, norm_sd, y):
     assert simplified.norm_mean == approx(norm_mean - np.log(y))
     assert simplified.norm_sd == approx(norm_sd)
 
+
 @given(
     x=st.floats(min_value=0.1, max_value=10),
     norm_mean=st.floats(min_value=-10, max_value=10),
-    norm_sd=st.floats(min_value=0.1, max_value=3)
+    norm_sd=st.floats(min_value=0.1, max_value=3),
 )
 @example(x=1, norm_mean=0, norm_sd=1)
 def test_simplify_div_constant_by_lognormal(x, norm_mean, norm_sd):
@@ -106,7 +115,7 @@ def test_simplify_div_constant_by_lognormal(x, norm_mean, norm_sd):
     assert simplified.norm_sd == approx(norm_sd)
 
 
-def test_simplify_lognormals():
+def test_simplify_div_lognormals():
     x = LognormalDistribution(norm_mean=1, norm_sd=1)
     y = LognormalDistribution(norm_mean=2, norm_sd=2)
     quotient = x / y
@@ -114,3 +123,36 @@ def test_simplify_lognormals():
     assert isinstance(simplified, LognormalDistribution)
     assert simplified.norm_mean == -1
     assert simplified.norm_sd == approx(np.sqrt(5))
+
+
+def test_simplify_div_normal_by_const():
+    x = NormalDistribution(mean=3, sd=1)
+    y = 2
+    simplified = (x / y).simplify()
+    assert isinstance(simplified, NormalDistribution)
+    assert simplified.mean == approx(1.5)
+    assert simplified.sd == approx(0.5)
+
+
+def test_simplify_div_const_by_normal():
+    x = 2
+    y = NormalDistribution(mean=3, sd=2)
+    simplified = (x / y).simplify()
+    assert isinstance(simplified, NormalDistribution)
+    assert simplified.mean == approx(2 / 3)
+    assert simplified.sd == approx(1)
+
+
+def test_simplify_lognorm_pow():
+    x = LognormalDistribution(norm_mean=3, norm_sd=2)
+    y = 2
+    product = x ** y
+    simplified = product.simplify()
+    assert isinstance(simplified, LognormalDistribution)
+    assert simplified.norm_mean == approx(6)
+    assert simplified.norm_sd == approx(4)
+
+    y = -1
+    product = x ** y
+    simplified = product.simplify()
+    assert isinstance(simplified, ComplexDistribution)

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,0 +1,55 @@
+from hypothesis import assume, example, given
+import hypothesis.strategies as st
+import numpy as np
+import pytest
+from pytest import approx
+
+from ..squigglepy.distributions import *
+
+def test_simplify_normal_add():
+    x = NormalDistribution(mean=1, sd=1)
+    y = NormalDistribution(mean=2, sd=2)
+    sum2 = x + y
+    simplified2 = sum2.simplify()
+    assert isinstance(simplified2, NormalDistribution)
+    assert simplified2.mean == 3
+    assert simplified2.sd == approx(np.sqrt(5))
+
+def test_simplify_normal_add3():
+    x = NormalDistribution(mean=1, sd=1)
+    y = NormalDistribution(mean=2, sd=2)
+    z = NormalDistribution(mean=-3, sd=2)
+    sum3_left = (x + y) + z
+    sum3_right = x + (y + z)
+    simplified3_left = sum3_left.simplify()
+    simplified3_right = sum3_right.simplify()
+    assert isinstance(simplified3_left, NormalDistribution)
+    assert simplified3_left.mean == 0
+    assert simplified3_left.sd == approx(np.sqrt(1 + 4 + 4))
+    assert isinstance(simplified3_right, NormalDistribution)
+    assert simplified3_right.mean == 0
+    assert simplified3_right.sd == approx(np.sqrt(1 + 4 + 4))
+
+def test_simplify_lognorm_mul3():
+    x = LognormalDistribution(norm_mean=1, norm_sd=1)
+    y = LognormalDistribution(norm_mean=2, norm_sd=2)
+    z = LognormalDistribution(norm_mean=-2, norm_sd=3)
+    product3_left = (x * y) * z
+    product3_right = x * (y * z)
+    simplified3_left = product3_left.simplify()
+    simplified3_right = product3_right.simplify()
+    assert isinstance(simplified3_left, LognormalDistribution)
+    assert simplified3_left.norm_mean == 1
+    assert simplified3_left.norm_sd == approx(np.sqrt(1 + 4 + 9))
+    assert isinstance(simplified3_right, LognormalDistribution)
+    assert simplified3_right.norm_mean == 1
+    assert simplified3_right.norm_sd == approx(np.sqrt(1 + 4 + 9))
+
+def test_simplify_sub():
+    x = NormalDistribution(mean=1, sd=1)
+    y = NormalDistribution(mean=2, sd=2)
+    difference = x - y
+    simplified = difference.simplify()
+    assert isinstance(simplified, NormalDistribution)
+    assert simplified.mean == -1
+    assert simplified.sd == approx(np.sqrt(5))

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -7,9 +7,9 @@ from pytest import approx
 from ..squigglepy.distributions import *
 
 
-def test_simplify_add_normal():
-    x = NormalDistribution(mean=1, sd=1)
-    y = NormalDistribution(mean=2, sd=2)
+def test_simplify_add_norm():
+    x = norm(mean=1, sd=1)
+    y = norm(mean=2, sd=2)
     sum2 = x + y
     simplified2 = sum2.simplify()
     assert isinstance(simplified2, NormalDistribution)
@@ -18,9 +18,9 @@ def test_simplify_add_normal():
 
 
 def test_simplify_add_3_normals():
-    x = NormalDistribution(mean=1, sd=1)
-    y = NormalDistribution(mean=2, sd=2)
-    z = NormalDistribution(mean=-3, sd=2)
+    x = norm(mean=1, sd=1)
+    y = norm(mean=2, sd=2)
+    z = norm(mean=-3, sd=2)
     sum3_left = (x + y) + z
     sum3_right = x + (y + z)
     simplified3_left = sum3_left.simplify()
@@ -34,17 +34,17 @@ def test_simplify_add_3_normals():
 
 
 def test_simplify_normal_plus_const():
-    x = NormalDistribution(mean=0, sd=1)
+    x = norm(mean=0, sd=1)
     y = 2
-    z = NormalDistribution(mean=1, sd=1)
+    z = norm(mean=1, sd=1)
     simplified = (x + y + z).simplify()
     assert isinstance(simplified, NormalDistribution)
     assert simplified.mean == 3
     assert simplified.sd == approx(np.sqrt(2))
 
 
-def simplify_scale_normal():
-    x = NormalDistribution(mean=2, sd=4)
+def simplify_scale_norm():
+    x = norm(mean=2, sd=4)
     y = 1.5
     product2 = x * y
     simplified = product2.simplify()
@@ -54,9 +54,9 @@ def simplify_scale_normal():
 
 
 def test_simplify_mul_3_lognorms():
-    x = LognormalDistribution(norm_mean=1, norm_sd=1)
-    y = LognormalDistribution(norm_mean=2, norm_sd=2)
-    z = LognormalDistribution(norm_mean=-2, norm_sd=3)
+    x = lognorm(norm_mean=1, norm_sd=1)
+    y = lognorm(norm_mean=2, norm_sd=2)
+    z = lognorm(norm_mean=-2, norm_sd=3)
     product3_left = (x * y) * z
     product3_right = x * (y * z)
     simplified3_left = product3_left.simplify()
@@ -70,8 +70,8 @@ def test_simplify_mul_3_lognorms():
 
 
 def test_simplify_sub_normals():
-    x = NormalDistribution(mean=1, sd=1)
-    y = NormalDistribution(mean=2, sd=2)
+    x = norm(mean=1, sd=1)
+    y = norm(mean=2, sd=2)
     difference = x - y
     simplified = difference.simplify()
     assert isinstance(simplified, NormalDistribution)
@@ -80,7 +80,7 @@ def test_simplify_sub_normals():
 
 
 def test_simplify_normal_minus_const():
-    x = NormalDistribution(mean=0, sd=1)
+    x = norm(mean=0, sd=1)
     y = 2
     simplified = (x - y).simplify()
     assert isinstance(simplified, NormalDistribution)
@@ -93,8 +93,8 @@ def test_simplify_normal_minus_const():
     norm_sd=st.floats(min_value=0.1, max_value=3),
     y=st.floats(min_value=0.1, max_value=10),
 )
-def test_simplify_div_lognormal_by_constant(norm_mean, norm_sd, y):
-    x = LognormalDistribution(norm_mean=norm_mean, norm_sd=norm_sd)
+def test_simplify_div_lognorm_by_constant(norm_mean, norm_sd, y):
+    x = lognorm(norm_mean=norm_mean, norm_sd=norm_sd)
     simplified = (x / y).simplify()
     assert isinstance(simplified, LognormalDistribution)
     assert simplified.norm_mean == approx(norm_mean - np.log(y))
@@ -107,17 +107,17 @@ def test_simplify_div_lognormal_by_constant(norm_mean, norm_sd, y):
     norm_sd=st.floats(min_value=0.1, max_value=3),
 )
 @example(x=1, norm_mean=0, norm_sd=1)
-def test_simplify_div_constant_by_lognormal(x, norm_mean, norm_sd):
-    y = LognormalDistribution(norm_mean=norm_mean, norm_sd=norm_sd)
+def test_simplify_div_constant_by_lognorm(x, norm_mean, norm_sd):
+    y = lognorm(norm_mean=norm_mean, norm_sd=norm_sd)
     simplified = (x / y).simplify()
     assert isinstance(simplified, LognormalDistribution)
     assert simplified.norm_mean == approx(np.log(x) - norm_mean)
     assert simplified.norm_sd == approx(norm_sd)
 
 
-def test_simplify_div_lognormals():
-    x = LognormalDistribution(norm_mean=1, norm_sd=1)
-    y = LognormalDistribution(norm_mean=2, norm_sd=2)
+def test_simplify_div_lognorms():
+    x = lognorm(norm_mean=1, norm_sd=1)
+    y = lognorm(norm_mean=2, norm_sd=2)
     quotient = x / y
     simplified = quotient.simplify()
     assert isinstance(simplified, LognormalDistribution)
@@ -126,7 +126,7 @@ def test_simplify_div_lognormals():
 
 
 def test_simplify_div_normal_by_const():
-    x = NormalDistribution(mean=3, sd=1)
+    x = norm(mean=3, sd=1)
     y = 2
     simplified = (x / y).simplify()
     assert isinstance(simplified, NormalDistribution)
@@ -134,17 +134,8 @@ def test_simplify_div_normal_by_const():
     assert simplified.sd == approx(0.5)
 
 
-def test_simplify_div_const_by_normal():
-    x = 2
-    y = NormalDistribution(mean=3, sd=2)
-    simplified = (x / y).simplify()
-    assert isinstance(simplified, NormalDistribution)
-    assert simplified.mean == approx(2 / 3)
-    assert simplified.sd == approx(1)
-
-
 def test_simplify_lognorm_pow():
-    x = LognormalDistribution(norm_mean=3, norm_sd=2)
+    x = lognorm(norm_mean=3, norm_sd=2)
     y = 2
     product = x**y
     simplified = product.simplify()
@@ -158,10 +149,10 @@ def test_simplify_lognorm_pow():
     assert isinstance(simplified, ComplexDistribution)
 
 
-def test_simplify_clipped_normal():
-    x = NormalDistribution(mean=1, sd=1)
-    y = NormalDistribution(mean=0, sd=1, lclip=1)
-    z = NormalDistribution(mean=3, sd=2)
+def test_simplify_clipped_norm():
+    x = norm(mean=1, sd=1)
+    y = norm(mean=0, sd=1, lclip=1)
+    z = norm(mean=3, sd=2)
     simplified = (x + y + z).simplify()
     assert isinstance(simplified, ComplexDistribution)
     assert isinstance(simplified.left, NormalDistribution)
@@ -171,3 +162,87 @@ def test_simplify_clipped_normal():
     assert simplified.right.mean == 0
     assert simplified.right.sd == 1
     assert simplified.right.lclip == 1
+
+
+def test_simplify_bernoulli_sum():
+    simplified = (bernoulli(p=0.5) + bernoulli(p=0.5)).simplify()
+    assert isinstance(simplified, BinomialDistribution)
+    assert simplified.n == 2
+    assert simplified.p == 0.5
+
+    # Cannot simplify if the probabilities are different
+    simplified = (bernoulli(p=0.5) + bernoulli(p=0.6)).simplify()
+    assert isinstance(simplified, ComplexDistribution)
+
+def test_simplify_bernoulli_plus_binomial():
+    simplified = (bernoulli(p=0.5) + binomial(n=10, p=0.2) + binomial(n=2, p=0.5) + binomial(n=3, p=0.5) + bernoulli(p=0.5)).simplify()
+    assert isinstance(simplified, ComplexDistribution)
+    assert isinstance(simplified.left, BinomialDistribution)
+    assert isinstance(simplified.right, BinomialDistribution)
+    assert simplified.left.n == 7
+    assert simplified.left.p == 0.5
+    assert simplified.right.n == 10
+    assert simplified.right.p == 0.2
+
+
+def test_simplify_gamma_sum():
+    simplified = (gamma(shape=2, scale=1) + gamma(shape=4, scale=1)).simplify()
+    assert isinstance(simplified, GammaDistribution)
+    assert simplified.shape == 6
+    assert simplified.scale == 1
+
+    # Cannot simplify if the scales are different
+    simplified = (gamma(shape=2, scale=1) + gamma(shape=2, scale=2)).simplify()
+    assert isinstance(simplified, ComplexDistribution)
+
+
+def test_simplify_scale_gamma():
+    simplified = (2 * gamma(shape=2, scale=3)).simplify()
+    assert isinstance(simplified, GammaDistribution)
+    assert simplified.shape == 2
+    assert simplified.scale == 6
+
+
+def test_simplify_exponential_sum():
+    simplified = (exponential(scale=2) + exponential(scale=2)).simplify()
+    assert isinstance(simplified, GammaDistribution)
+    assert simplified.shape == 2
+    assert simplified.scale == 2
+
+    # Cannot simplify if the rates are different
+    simplified = (exponential(scale=2) + exponential(scale=3)).simplify()
+    assert isinstance(simplified, ComplexDistribution)
+
+
+def test_simplify_exponential_gamma_sum():
+    simplified = (5 * (exponential(scale=3) + gamma(shape=2, scale=3) + exponential(scale=3))).simplify()
+    assert isinstance(simplified, GammaDistribution)
+    assert simplified.shape == 4
+    assert simplified.scale == 15
+
+
+def test_simplify_big_sum():
+    simplified = (
+        2 * norm(mean=1, sd=1)
+        + lognorm(norm_mean=1, norm_sd=1) * lognorm(norm_mean=3, norm_sd=2)
+        + gamma(shape=2, scale=3)
+        + exponential(scale=3) / 5
+        + exponential(scale=3)
+        - norm(mean=2, sd=1)
+    ).simplify()
+
+    # simplifies to norm(0, sqrt(5)) + lognorm(4, sqrt(5)) + gamma(3, 3) + exponential(6)
+    assert isinstance(simplified, ComplexDistribution)
+    assert isinstance(simplified.right, ExponentialDistribution)
+    assert simplified.right.scale == approx(3 / 5)
+    assert isinstance(simplified.left, ComplexDistribution)
+    assert isinstance(simplified.left.right, GammaDistribution)
+    assert simplified.left.right.shape == 3
+    assert simplified.left.right.scale == 3
+    assert isinstance(simplified.left.left, ComplexDistribution)
+    assert isinstance(simplified.left.left.right, LognormalDistribution)
+    assert simplified.left.left.right.norm_mean == 4
+    assert simplified.left.left.right.norm_sd == approx(np.sqrt(5))
+    assert isinstance(simplified.left.left.left, NormalDistribution)
+    assert simplified.left.left.left.mean == 0
+    assert simplified.left.left.left.sd == approx(np.sqrt(5))

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,5 +1,6 @@
 from hypothesis import assume, example, given
 import hypothesis.strategies as st
+from numbers import Real
 import numpy as np
 import pytest
 from pytest import approx
@@ -246,3 +247,16 @@ def test_simplify_big_sum():
     assert isinstance(simplified.left.left.left, NormalDistribution)
     assert simplified.left.left.left.mean == 0
     assert simplified.left.left.left.sd == approx(np.sqrt(5))
+
+
+def test_preserve_non_commutative_op():
+    simplified = (2 ** 3 ** norm(mean=0, sd=1)).simplify()
+    assert isinstance(simplified, ComplexDistribution)
+    assert simplified.fn_str == "**"
+    assert isinstance(simplified.left, Real)
+    assert simplified.left == 2
+    assert isinstance(simplified.right, ComplexDistribution)
+    assert simplified.right.fn_str == "**"
+    assert isinstance(simplified.right.left, Real)
+    assert simplified.right.left == 3
+    assert isinstance(simplified.right.right, NormalDistribution)

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -6,7 +6,7 @@ from pytest import approx
 
 from ..squigglepy.distributions import *
 
-def test_simplify_normal_add():
+def test_simplify_add_normal():
     x = NormalDistribution(mean=1, sd=1)
     y = NormalDistribution(mean=2, sd=2)
     sum2 = x + y
@@ -15,7 +15,7 @@ def test_simplify_normal_add():
     assert simplified2.mean == 3
     assert simplified2.sd == approx(np.sqrt(5))
 
-def test_simplify_normal_add3():
+def test_simplify_add_3_normals():
     x = NormalDistribution(mean=1, sd=1)
     y = NormalDistribution(mean=2, sd=2)
     z = NormalDistribution(mean=-3, sd=2)
@@ -30,7 +30,25 @@ def test_simplify_normal_add3():
     assert simplified3_right.mean == 0
     assert simplified3_right.sd == approx(np.sqrt(1 + 4 + 4))
 
-def test_simplify_lognorm_mul3():
+def test_simplify_normal_plus_const():
+    x = NormalDistribution(mean=0, sd=1)
+    y = 2
+    sum2 = x + y
+    simplified = sum2.simplify()
+    assert isinstance(simplified, NormalDistribution)
+    assert simplified.mean == 2
+    assert simplified.sd == approx(1)
+
+def simplify_scale_normal():
+    x = NormalDistribution(mean=2, sd=4)
+    y = 1.5
+    product2 = x * y
+    simplified = product2.simplify()
+    assert isinstance(simplified, NormalDistribution)
+    assert simplified.mean == approx(3)
+    assert simplified.sd == approx(6)
+
+def test_simplify_mul_3_normals():
     x = LognormalDistribution(norm_mean=1, norm_sd=1)
     y = LognormalDistribution(norm_mean=2, norm_sd=2)
     z = LognormalDistribution(norm_mean=-2, norm_sd=3)

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -126,13 +126,27 @@ def test_simplify_div_lognorms():
     assert simplified.norm_sd == approx(np.sqrt(5))
 
 
-def test_simplify_div_normal_by_const():
+def test_simplify_div_norm_by_const():
     x = norm(mean=3, sd=1)
     y = 2
     simplified = (x / y).simplify()
     assert isinstance(simplified, NormalDistribution)
     assert simplified.mean == approx(1.5)
     assert simplified.sd == approx(0.5)
+
+
+def test_simplify_div_norm_by_lognorm():
+    x = norm(mean=3, sd=1)
+    y = lognorm(norm_mean=2, norm_sd=2)
+    simplified = (x / y).simplify()
+    assert isinstance(simplified, ComplexDistribution)
+    assert simplified.fn_str == "*"
+    assert isinstance(simplified.left, NormalDistribution)
+    assert simplified.left.mean == 3
+    assert simplified.left.sd == 1
+    assert isinstance(simplified.right, LognormalDistribution)
+    assert simplified.right.norm_mean == -2
+    assert simplified.right.norm_sd == approx(2)
 
 
 def test_simplify_lognorm_pow():


### PR DESCRIPTION
Implement the ability to analytically simplify common combinations of distributions, for example the sum of two normal distributions is normal and the product of two log-normal distributions is log-normal.

The analytic simplification is performed by `Distribution.simplify()` which calls out to a helper class `FlatTree`.

I also modified `sq.sample()` to automatically call `simplify()` before sampling.

This PR is most useful in conjunction with #61. Performing analytic reductions before falling back to numeric methods increases both speed and accuracy. Without support for numeric methods, analytic reduction does increase the speed of Monte Carlo sampling, but probably only by a modest constant factor (eg if half the distributions in your model can be combined analytically, it doubles the speed), and it doesn't increase accuracy at all.